### PR TITLE
Add optional reviewer to PRs

### DIFF
--- a/createpullrequest/createPullRequest.ts
+++ b/createpullrequest/createPullRequest.ts
@@ -57,6 +57,13 @@ async function run() {
     createPullRequest.completionOptions.bypassPolicy = tl.getBoolInput("bypassPolicy");
     createPullRequest.completionOptions.deleteSourceBranch = tl.getBoolInput("deleteSourceBranch");
     createPullRequest.completionOptions.squashMerge = tl.getBoolInput("squashMerge");
+    
+    const requestedByAsReviewer = tl.getBoolInput("requestedByAsReviewer");
+    createPullRequest.reviewers = [];
+    if (requestedByAsReviewer) {
+        const reviewer = <gi.IdentityRefWithVote> {id: tl.getVariable("Build.RequestedForId")}
+        createPullRequest.reviewers.push(reviewer);
+    }
 
     let pullRequest: gi.GitPullRequest = await gitApi.createPullRequest(createPullRequest, repository.id, project, true);
     console.log(`created pull request with id ${pullRequest.pullRequestId}`);

--- a/createpullrequest/task.json
+++ b/createpullrequest/task.json
@@ -61,6 +61,14 @@
             "groupName": "policies"
         },
         {
+            "name": "requestedByAsReviewer",
+            "type": "boolean",
+            "label": "Add user requesting build as reviewer",
+            "required": false,
+            "helpMarkDown": "If checked the user identified by `$(Build.RequestedForId)` will be added as a reviewer",
+            "groupName": "policies"
+        },
+        {
             "name": "autoComplete",
             "type": "boolean",
             "label": "Auto complete",
@@ -77,7 +85,6 @@
             "required": false,
             "helpMarkDown": "Bypass policies set on the branch the pull request merges into.",
             "groupName": "completion"
-
         },
         {
             "name": "deleteSourceBranch",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -16,7 +16,7 @@
     ],    
     "description": "Git related tasks for VSTS",
     "categories": [
-        "Build and release"
+        "Azure Pipelines"
     ],
     "screenshots": [
         {
@@ -57,16 +57,16 @@
     },
     "files": [
         {
-            "path": "createPullRequest/createPullRequest.js"
+            "path": "createpullrequest/createPullRequest.js"
           },
           {
-            "path": "createPullRequest/node_modules"
+            "path": "createpullrequest/node_modules"
           },
           {
-            "path": "createPullRequest/task.json"
+            "path": "createpullrequest/task.json"
           },
           {
-            "path": "createPullRequest/icon.png"
+            "path": "createpullrequest/icon.png"
       }
     ],
     "contributions": [


### PR DESCRIPTION
This change introduces the ability to automatically add the user that
the build was requested for as a reviewer. This ensures that if there
are merge conflicts it will be easier for people to find the PR in ADO.

This is what the UI looks like now (note the additional checkbox under policies)
![image](https://user-images.githubusercontent.com/152342/54186050-c0b92900-44aa-11e9-82e5-acaad35232fa.png)
